### PR TITLE
Update QFFmpegGLWidget.cpp

### DIFF
--- a/QFFmpegGLWidget.cpp
+++ b/QFFmpegGLWidget.cpp
@@ -89,11 +89,18 @@ void QFFmpegGLWidget::initializeGL()
     glTexParameteri(GL_TEXTURE_2D,GL_TEXTURE_MIN_FILTER,GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D,GL_TEXTURE_MAG_FILTER,GL_LINEAR);
 
-    glEnable(GL_TEXTURE_2D);
-    glShadeModel(GL_SMOOTH);
+    glEnable(GL_TEXTURE_2D
+    
+    /* The following three commented lines if uncommented generate following errors:
+     * undefined reference to `_imp__glShadeModel@4'
+     * undefined reference to `_imp__glClearDepth@8'
+     * bad reloc address 0x20 in section `.eh_frame'
+     */
+     
+   // glShadeModel(GL_SMOOTH);
     glClearColor(0.0f, 0.0f, 0.0f, 0.5f);
-    glClearDepth(1.0f);
-    glEnable(GL_DEPTH_TEST);
+   // glClearDepth(1.0f);
+   // glEnable(GL_DEPTH_TEST);
 
     glDepthFunc(GL_LEQUAL);
     glHint(GL_PERSPECTIVE_CORRECTION_HINT, GL_NICEST);


### PR DESCRIPTION
To avoid some 'undefined references' the following lines of code can safely be commented out without affecting the output significantly;
    glShadeModel(GL_SMOOTH);
    glClearDepth(1.0f);
    glEnable(GL_DEPTH_TEST);

Errors are:
undefined reference to `_imp__glShadeModel@4'
undefined reference to`_imp__glClearDepth@8'
bad reloc address 0x20 in section `.eh_frame'

As far as i think these errors are occurring as i don't have updated opengl drivers/Graphics Card.
